### PR TITLE
テトリミノの色分け

### DIFF
--- a/js/model/gameModel.js
+++ b/js/model/gameModel.js
@@ -37,36 +37,36 @@ class GameModel {
             //O
             {shape: [[1,1],
                      [1,1]],
-             color: "yellow"
+             color: "#FFFF00"
             },
             //I
-            {shape: [[1,1,1,1]],
-             color: "ligthblue"
+            {shape: [[2,2,2,2]],
+             color: "#00FFFF"
             },
             //T
-            {shape: [[0,1,0],
-                     [1,1,1]],
-             color: "purple"
+            {shape: [[0,3,0],
+                     [3,3,3]],
+             color: "#9400D3"
             },
             //L
-            {shape: [[0,0,1],
-                     [1,1,1]],
-             color: "olange"
+            {shape: [[0,0,4],
+                     [4,4,4]],
+             color: "#FFA500"
             },
             //J
-            {shape: [[1,0,0],
-                     [1,1,1]],
-             color: "darkblue"
+            {shape: [[5,0,0],
+                     [5,5,5]],
+             color: "#0000FF"
             },
             //Z
-            {shape: [[0,1,1],
-                     [1,1,0]],
-             color: "green"
+            {shape: [[0,6,6],
+                     [6,6,0]],
+             color: "#32CD32"
             },
             //S
-            {shape: [[1,1,0],
-                     [0,1,1]],
-             color: "red"}
+            {shape: [[7,7,0],
+                     [0,7,7]],
+             color: "#FF0000"}
         ]
         const block = blocks[Math.floor(Math.random()*blocks.length)];
         return {

--- a/js/view/gameView.js
+++ b/js/view/gameView.js
@@ -30,6 +30,7 @@ class GameView {
     drawGrid(grid) {
         for (let y = 0; y < grid.length; y++) {
             for (let x = 0; x < grid[y].length; x++) {
+                /*
                 if (grid[y][x] === 0) {
                     // 空のセルの場合は暗い色で描画
                     this.context.fillStyle = '#151515'; // グリッドのセルの色
@@ -37,13 +38,40 @@ class GameView {
                     // テトリミノのセルの場合は明るい色で描画
                     this.context.fillStyle = '#f00'; // テトリミノのセルの色
                 }
+                */
+               switch (grid[y][x]) {
+                    case 0:
+                        this.context.fillStyle = '#151515'; // グリッドのセルの色
+                        break;
+                    case 1:
+                        this.context.fillStyle = "#FFFF00"; // Oテトリミノのセルの色
+                        break;
+                    case 2:
+                        this.context.fillStyle = "#00FFFF"; // Iテトリミノのセルの色
+                        break;
+                    case 3:
+                        this.context.fillStyle = "#9400D3"; // Tテトリミノのセルの色
+                        break;
+                    case 4:
+                        this.context.fillStyle = "#FFA500"; // Lテトリミノのセルの色
+                        break;
+                    case 5:
+                        this.context.fillStyle = "#0000FF"; // Jテトリミノのセルの色
+                        break;
+                    case 6:
+                        this.context.fillStyle = "#32CD32"; // Zテトリミノのセルの色
+                        break;
+                    case 7:
+                        this.context.fillStyle = "#FF0000"; // Sテトリミノのセルの色
+                        break;
+                }   
                 this.context.fillRect(x * this.cellSize + 0.5, y * this.cellSize + 0.5, this.cellSize, this.cellSize);
             }
         }
     }
 
     drawTetromino(tetromino) {
-        this.context.fillStyle = '#f00'; // テトリミノの色
+        this.context.fillStyle = tetromino.color; // テトリミノの色
         tetromino.shape.forEach((row, dy) => {
             row.forEach((value, dx) => {
                 if (value) {

--- a/js/view/gameView.js
+++ b/js/view/gameView.js
@@ -30,15 +30,6 @@ class GameView {
     drawGrid(grid) {
         for (let y = 0; y < grid.length; y++) {
             for (let x = 0; x < grid[y].length; x++) {
-                /*
-                if (grid[y][x] === 0) {
-                    // 空のセルの場合は暗い色で描画
-                    this.context.fillStyle = '#151515'; // グリッドのセルの色
-                } else {
-                    // テトリミノのセルの場合は明るい色で描画
-                    this.context.fillStyle = '#f00'; // テトリミノのセルの色
-                }
-                */
                switch (grid[y][x]) {
                     case 0:
                         this.context.fillStyle = '#151515'; // グリッドのセルの色


### PR DESCRIPTION
#6 #11 
テトリミノが色分けできるようにテトリミノの定義を1~7の数字で表すようにしました。
また、カラーコードをいい感じに変更しました。
これは0121hamuブランチへのプルリクなのでマージした後、pullすることを忘れないようにしてください。